### PR TITLE
OpenShift version update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,9 @@ dotmap==1.2.20
 enum34==1.1.6
 flake8==3.5.0
 kiali-client==0.4.4
+openshift==0.6.0
 pytest==3.5.1
 pytest_jira==0.3.6
 pyyaml==3.12
 selenium==3.12.0
 widgetastic.core==0.21.2
-openshift==0.5.0


### PR DESCRIPTION
* Openshift version needs to be updated to `0.6.0` to use `Dynamic client`.
* Generated client - DEPRECATED (0.5.0)