### PR TITLE
Mark tests according to collision areas.

### DIFF
--- a/kiali_qe/tests/test_applications_page.py
+++ b/kiali_qe/tests/test_applications_page.py
@@ -4,6 +4,7 @@ from kiali_qe.tests import ApplicationsPageTest
 from kiali_qe.components.enums import ApplicationsPageFilter
 
 
+@pytest.mark.p_ro_namespace
 @pytest.mark.p_group9
 def test_pagination_feature(kiali_client, openshift_client, browser):
     tests = ApplicationsPageTest(
@@ -14,6 +15,7 @@ def test_pagination_feature(kiali_client, openshift_client, browser):
     tests.assert_pagination_feature()
 
 
+@pytest.mark.p_ro_top_safe
 @pytest.mark.p_group4
 def test_namespaces(kiali_client, openshift_client, browser):
     tests = ApplicationsPageTest(
@@ -21,6 +23,7 @@ def test_namespaces(kiali_client, openshift_client, browser):
     tests.assert_namespaces()
 
 
+@pytest.mark.p_atomic
 @pytest.mark.p_group4
 def test_filter_options(kiali_client, openshift_client, browser):
     tests = ApplicationsPageTest(
@@ -28,6 +31,9 @@ def test_filter_options(kiali_client, openshift_client, browser):
     tests.assert_filter_options()
 
 
+# putting to p_ro_top group although right now there are no tests changing health of app so
+# it could be in p_ro_top_safe
+@pytest.mark.p_ro_top
 @pytest.mark.p_group4
 def test_all_applications(kiali_client, openshift_client, browser):
     tests = ApplicationsPageTest(
@@ -35,6 +41,9 @@ def test_all_applications(kiali_client, openshift_client, browser):
     tests.assert_all_items(filters=[])
 
 
+# putting to p_ro_top group although right now there are no tests changing health of app so
+# it could be in p_ro_top_safe
+@pytest.mark.p_ro_top
 @pytest.mark.p_group4
 def test_application_details_random(kiali_client, openshift_client, browser):
     tests = ApplicationsPageTest(

--- a/kiali_qe/tests/test_graph_page.py
+++ b/kiali_qe/tests/test_graph_page.py
@@ -12,6 +12,7 @@ from kiali_qe.utils import is_equal
 from kiali_qe.utils.log import logger
 
 
+@pytest.mark.p_atomic
 @pytest.mark.p_group8
 def test_duration(browser):
     # get page instance
@@ -25,6 +26,7 @@ def test_duration(browser):
         ('Options mismatch: defined:{}, listed:{}'.format(options_defined, options_listed))
 
 
+@pytest.mark.p_atomic
 @pytest.mark.p_group8
 def test_refresh_interval(browser):
     # get page instance
@@ -38,6 +40,7 @@ def test_refresh_interval(browser):
         ('Options mismatch: defined:{}, listed:{}'.format(options_defined, options_listed))
 
 
+@pytest.mark.p_atomic
 @pytest.mark.p_group8
 def test_type(browser):
     # get page instance
@@ -50,6 +53,7 @@ def test_type(browser):
         ('Options mismatch: defined:{}, listed:{}'.format(options_defined, options_listed))
 
 
+@pytest.mark.p_atomic
 @pytest.mark.p_group8
 def test_filter(browser):
     # get page instance

--- a/kiali_qe/tests/test_istio_config_page.py
+++ b/kiali_qe/tests/test_istio_config_page.py
@@ -5,6 +5,7 @@ from kiali_qe.components.enums import IstioConfigPageFilter
 BOOKINFO_2 = 'bookinfo2'
 
 
+@pytest.mark.p_ro_namespace
 @pytest.mark.p_group6
 def test_pagination_feature(kiali_client, openshift_client, browser):
     tests = IstioConfigPageTest(
@@ -16,6 +17,7 @@ def test_pagination_feature(kiali_client, openshift_client, browser):
     tests.assert_pagination_feature()
 
 
+@pytest.mark.p_ro_top_safe
 @pytest.mark.p_group7
 def test_namespaces(kiali_client, openshift_client, browser):
     tests = IstioConfigPageTest(
@@ -23,6 +25,7 @@ def test_namespaces(kiali_client, openshift_client, browser):
     tests.assert_namespaces()
 
 
+@pytest.mark.p_atomic
 @pytest.mark.p_group7
 def test_filter_options(kiali_client, openshift_client, browser):
     tests = IstioConfigPageTest(
@@ -31,6 +34,7 @@ def test_filter_options(kiali_client, openshift_client, browser):
 
 
 # p_group_last is used for tests which must be run at the end when all other test are done
+@pytest.mark.p_ro_top
 @pytest.mark.p_group_last
 def test_filter_feature_random(kiali_client, openshift_client, browser):
     tests = IstioConfigPageTest(
@@ -38,6 +42,7 @@ def test_filter_feature_random(kiali_client, openshift_client, browser):
     tests.assert_filter_feature_random()
 
 
+@pytest.mark.p_ro_top
 @pytest.mark.p_group_last
 def test_all_configs(kiali_client, openshift_client, browser):
     tests = IstioConfigPageTest(
@@ -45,6 +50,7 @@ def test_all_configs(kiali_client, openshift_client, browser):
     tests.assert_all_items(filters=[])
 
 
+@pytest.mark.p_ro_namespace
 @pytest.mark.p_group5
 def test_config_details_random(kiali_client, openshift_client, browser, pick_namespace):
     tests = IstioConfigPageTest(

--- a/kiali_qe/tests/test_istio_objects_crud.py
+++ b/kiali_qe/tests/test_istio_objects_crud.py
@@ -34,6 +34,7 @@ GATEWAY = 'gateway.yaml'
 SERVICE_ENTRY = 'service-entry.yaml'
 
 
+@pytest.mark.p_crud_resource
 @pytest.mark.p_group1
 def test_destination_rule(kiali_client, openshift_client, browser):
     destination_rule = get_yaml(istio_objects_path.strpath, DEST_RULE)
@@ -57,6 +58,7 @@ def test_destination_rule(kiali_client, openshift_client, browser):
                        service_name=DETAILS)
 
 
+@pytest.mark.p_crud_resource
 @pytest.mark.p_group1
 def test_destination_rule_broken(kiali_client, openshift_client, browser):
     destination_rule_broken = get_yaml(istio_objects_path.strpath, DEST_RULE_BROKEN)
@@ -80,6 +82,7 @@ def test_destination_rule_broken(kiali_client, openshift_client, browser):
                        service_name=DETAILS)
 
 
+@pytest.mark.p_crud_resource
 @pytest.mark.p_group2
 def test_virtual_service(kiali_client, openshift_client, browser):
     virtual_service = get_yaml(istio_objects_path.strpath, VIRTUAL_SERVICE)
@@ -105,6 +108,7 @@ def test_virtual_service(kiali_client, openshift_client, browser):
     _delete_dest_rule_vs(openshift_client, DEST_RULE_VS_REVIEWS)
 
 
+@pytest.mark.p_crud_resource
 @pytest.mark.p_group2
 def test_virtual_service_broken(kiali_client, openshift_client, browser):
     virtual_service_broken = get_yaml(istio_objects_path.strpath, VIRTUAL_SERVICE_BROKEN)
@@ -130,6 +134,7 @@ def test_virtual_service_broken(kiali_client, openshift_client, browser):
     _delete_dest_rule_vs(openshift_client, DEST_RULE_VS_REVIEWS)
 
 
+@pytest.mark.p_crud_resource
 @pytest.mark.p_group2
 def test_virtual_service_broken_weight(kiali_client, openshift_client, browser):
     virtual_service_broken = get_yaml(istio_objects_path.strpath,
@@ -157,6 +162,7 @@ def test_virtual_service_broken_weight(kiali_client, openshift_client, browser):
     _delete_dest_rule_vs(openshift_client, DEST_RULE_VS_REVIEWS)
 
 
+@pytest.mark.p_crud_resource
 @pytest.mark.p_group3
 def test_virtual_service_broken_weight_text(kiali_client, openshift_client, browser):
     virtual_service_broken = get_yaml(istio_objects_path.strpath,
@@ -184,6 +190,7 @@ def test_virtual_service_broken_weight_text(kiali_client, openshift_client, brow
     _delete_dest_rule_vs(openshift_client, DEST_RULE_VS_RATINGS)
 
 
+@pytest.mark.p_crud_resource
 @pytest.mark.p_group3
 def test_quota_spec(kiali_client, openshift_client, browser):
     quota_spec = get_yaml(istio_objects_path.strpath, QUOTA_SPEC)
@@ -205,6 +212,7 @@ def test_quota_spec(kiali_client, openshift_client, browser):
                        service_name=RATINGS)
 
 
+@pytest.mark.p_crud_resource
 @pytest.mark.p_group3
 def test_quota_spec_binding(kiali_client, openshift_client, browser):
     quota_spec_binding = get_yaml(istio_objects_path.strpath, QUOTA_SPEC_BINDING)
@@ -226,6 +234,7 @@ def test_quota_spec_binding(kiali_client, openshift_client, browser):
                        service_name=RATINGS)
 
 
+@pytest.mark.p_crud_resource
 @pytest.mark.p_group5
 def test_gateway(kiali_client, openshift_client, browser, pick_namespace):
     gateway = get_yaml(istio_objects_path.strpath, GATEWAY)
@@ -248,6 +257,7 @@ def test_gateway(kiali_client, openshift_client, browser, pick_namespace):
                        service_name=REVIEWS)
 
 
+@pytest.mark.p_crud_resource
 @pytest.mark.p_group1
 def test_service_entry(kiali_client, openshift_client, browser):
     yaml = get_yaml(istio_objects_path.strpath, SERVICE_ENTRY)

--- a/kiali_qe/tests/test_login.py
+++ b/kiali_qe/tests/test_login.py
@@ -4,6 +4,7 @@ from kiali_qe.pages import RootPage
 from kiali_qe.utils.log import logger
 
 
+@pytest.mark.p_atomic
 @pytest.mark.p_group8
 def test_login(browser):
     # load root page
@@ -18,6 +19,7 @@ def test_login(browser):
     assert not page.notifications.contains(_type=Notification.TYPE_WARNING)
 
 
+@pytest.mark.p_atomic
 @pytest.mark.p_group8
 def test_invalid_login(browser):
     # load root page

--- a/kiali_qe/tests/test_menu.py
+++ b/kiali_qe/tests/test_menu.py
@@ -6,6 +6,7 @@ from kiali_qe.utils import is_equal
 from kiali_qe.utils.log import logger
 
 
+@pytest.mark.p_atomic
 @pytest.mark.p_group9
 def test_menu(browser):
     # load root page
@@ -25,6 +26,7 @@ def test_menu(browser):
         assert page.main_menu.selected == _menu
 
 
+@pytest.mark.p_atomic
 @pytest.mark.p_group9
 def test_toggle(browser):
     # load root page
@@ -35,6 +37,7 @@ def test_toggle(browser):
     assert not page.main_menu.is_collapsed
 
 
+@pytest.mark.p_atomic
 @pytest.mark.p_group9
 def test_help_menu(browser):
     # load root page
@@ -46,6 +49,7 @@ def test_help_menu(browser):
         ('Help menu mismatch: defined:{}, listed:{}'.format(options_defined, options_listed))
 
 
+@pytest.mark.p_atomic
 @pytest.mark.p_group9
 def test_user_menu(browser):
     # load root page

--- a/kiali_qe/tests/test_navbar.py
+++ b/kiali_qe/tests/test_navbar.py
@@ -6,6 +6,7 @@ from kiali_qe.utils import is_equal
 from kiali_qe.utils.log import logger
 
 
+@pytest.mark.p_atomic
 @pytest.mark.p_group10
 def test_about(browser, kiali_client):
     # load root page
@@ -51,6 +52,7 @@ def _get_version(versions, key):
             return item['version']
 
 
+@pytest.mark.p_atomic
 @pytest.mark.p_group10
 def test_help_menu(browser):
     # load root page

--- a/kiali_qe/tests/test_overview_page.py
+++ b/kiali_qe/tests/test_overview_page.py
@@ -3,6 +3,7 @@ import pytest
 from kiali_qe.tests import OverviewPageTest
 
 
+@pytest.mark.p_atomic
 @pytest.mark.p_group6
 def test_filter_options(kiali_client, openshift_client, browser):
     tests = OverviewPageTest(
@@ -10,6 +11,9 @@ def test_filter_options(kiali_client, openshift_client, browser):
     tests.assert_filter_options()
 
 
+# putting to p_ro_top group although right now there are no tests changing health of app so
+# it could be in p_ro_top_safe
+@pytest.mark.p_ro_top
 @pytest.mark.p_group6
 def test_all_overviews(kiali_client, openshift_client, browser):
     tests = OverviewPageTest(

--- a/kiali_qe/tests/test_services_page.py
+++ b/kiali_qe/tests/test_services_page.py
@@ -6,6 +6,7 @@ from kiali_qe.components.enums import ServicesPageFilter
 BOOKINFO_2 = 'bookinfo2'
 
 
+@pytest.mark.p_ro_namespace
 @pytest.mark.p_group9
 def test_pagination_feature(kiali_client, openshift_client, browser):
     tests = ServicesPageTest(
@@ -16,6 +17,7 @@ def test_pagination_feature(kiali_client, openshift_client, browser):
     tests.assert_pagination_feature()
 
 
+@pytest.mark.p_ro_top_safe
 @pytest.mark.p_group4
 def test_namespaces(kiali_client, openshift_client, browser):
     tests = ServicesPageTest(
@@ -23,6 +25,7 @@ def test_namespaces(kiali_client, openshift_client, browser):
     tests.assert_namespaces()
 
 
+@pytest.mark.p_atomic
 @pytest.mark.p_group4
 def test_filter_options(kiali_client, openshift_client, browser):
     tests = ServicesPageTest(
@@ -30,6 +33,9 @@ def test_filter_options(kiali_client, openshift_client, browser):
     tests.assert_filter_options()
 
 
+# putting to p_ro_top group although right now there are no tests changing health of app so
+# it could be in p_ro_top_safe
+@pytest.mark.p_ro_top
 @pytest.mark.p_group4
 def test_filter_feature_random(kiali_client, openshift_client, browser):
     tests = ServicesPageTest(
@@ -37,6 +43,9 @@ def test_filter_feature_random(kiali_client, openshift_client, browser):
     tests.assert_filter_feature_random()
 
 
+# putting to p_ro_top group although right now there are no tests changing health of app so
+# it could be in p_ro_top_safe
+@pytest.mark.p_ro_top
 @pytest.mark.p_group4
 def test_all_services(kiali_client, openshift_client, browser):
     tests = ServicesPageTest(
@@ -44,6 +53,7 @@ def test_all_services(kiali_client, openshift_client, browser):
     tests.assert_all_items(filters=[])
 
 
+@pytest.mark.p_ro_namespace
 @pytest.mark.p_group5
 def test_service_details_random(kiali_client, openshift_client, browser, pick_namespace):
     tests = ServicesPageTest(

--- a/kiali_qe/tests/test_workloads_page.py
+++ b/kiali_qe/tests/test_workloads_page.py
@@ -4,6 +4,7 @@ from kiali_qe.tests import WorkloadsPageTest
 from kiali_qe.components.enums import WorkloadsPageFilter
 
 
+@pytest.mark.p_ro_namespace
 @pytest.mark.p_group9
 def test_pagination_feature(kiali_client, openshift_client, browser):
     tests = WorkloadsPageTest(
@@ -14,6 +15,7 @@ def test_pagination_feature(kiali_client, openshift_client, browser):
     tests.assert_pagination_feature()
 
 
+@pytest.mark.p_ro_top_safe
 @pytest.mark.p_group7
 def test_namespaces(kiali_client, openshift_client, browser):
     tests = WorkloadsPageTest(
@@ -21,6 +23,7 @@ def test_namespaces(kiali_client, openshift_client, browser):
     tests.assert_namespaces()
 
 
+@pytest.mark.p_atomic
 @pytest.mark.p_group7
 def test_filter_options(kiali_client, openshift_client, browser):
     tests = WorkloadsPageTest(
@@ -28,6 +31,9 @@ def test_filter_options(kiali_client, openshift_client, browser):
     tests.assert_filter_options()
 
 
+# putting to p_ro_top group although right now there are no tests changing health of app so
+# it could be in p_ro_top_safe
+@pytest.mark.p_ro_top
 @pytest.mark.p_group7
 def test_all_workloads(kiali_client, openshift_client, browser):
     tests = WorkloadsPageTest(
@@ -35,6 +41,9 @@ def test_all_workloads(kiali_client, openshift_client, browser):
     tests.assert_all_items(filters=[])
 
 
+# putting to p_ro_top group although right now there are no tests changing health of app so
+# it could be in p_ro_top_safe
+@pytest.mark.p_ro_top
 @pytest.mark.p_group7
 def test_workload_details_random(kiali_client, openshift_client, browser):
     tests = WorkloadsPageTest(

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,3 +13,11 @@ markers =
     p_group10
     p_group_last
     hookwrapper
+    p_ro_namespace
+    p_ro_resource
+    p_ro_top_safe
+    p_ro_top
+    p_atomic
+    p_crud_resource
+    p_crud_namespace
+    p_crud_top


### PR DESCRIPTION
Added metadata for each test which is defining collision areas in case of
parallel run. Right now there is no automation logic behind that or any
automatic test grouping for parallel runs.