### PR TITLE
New grouping for UI tests parallel run.

### DIFF
--- a/kiali_qe/tests/test_applications_page.py
+++ b/kiali_qe/tests/test_applications_page.py
@@ -8,7 +8,7 @@ ISTIO_SYSTEM = 'istio-system'
 
 
 @pytest.mark.p_ro_namespace
-@pytest.mark.p_group9
+@pytest.mark.p_ro_group5
 def test_pagination_feature(kiali_client, openshift_client, browser):
     tests = ApplicationsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -18,7 +18,7 @@ def test_pagination_feature(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_ro_top_safe
-@pytest.mark.p_group4
+@pytest.mark.p_ro_group5
 def test_namespaces(kiali_client, openshift_client, browser):
     tests = ApplicationsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -26,7 +26,7 @@ def test_namespaces(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group4
+@pytest.mark.p_ro_group1
 def test_filter_options(kiali_client, openshift_client, browser):
     tests = ApplicationsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -34,7 +34,7 @@ def test_filter_options(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group4
+@pytest.mark.p_ro_group1
 def test_sort_options(kiali_client, openshift_client, browser):
     tests = ApplicationsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -44,7 +44,7 @@ def test_sort_options(kiali_client, openshift_client, browser):
 # putting to p_ro_top group although right now there are no tests changing health of app so
 # it could be in p_ro_top_safe
 @pytest.mark.p_ro_top
-@pytest.mark.p_group4
+@pytest.mark.p_ro_group1
 def test_all_applications(kiali_client, openshift_client, browser):
     tests = ApplicationsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -52,7 +52,7 @@ def test_all_applications(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_ro_top
-@pytest.mark.p_group4
+@pytest.mark.p_ro_group1
 def test_all_applications_namespace(kiali_client, openshift_client, browser):
     tests = ApplicationsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -63,7 +63,7 @@ def test_all_applications_namespace(kiali_client, openshift_client, browser):
 # putting to p_ro_top group although right now there are no tests changing health of app so
 # it could be in p_ro_top_safe
 @pytest.mark.p_ro_top
-@pytest.mark.p_group4
+@pytest.mark.p_ro_group1
 def test_application_details_random(kiali_client, openshift_client, browser, pick_namespace):
     tests = ApplicationsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)

--- a/kiali_qe/tests/test_breadcrumb.py
+++ b/kiali_qe/tests/test_breadcrumb.py
@@ -15,7 +15,7 @@ ISTIO_SYSTEM = 'istio-system'
 # putting to p_ro_top group although right now there are no tests changing health of app so
 # it could be in p_ro_top_safe
 @pytest.mark.p_ro_top
-@pytest.mark.p_group7
+@pytest.mark.p_ro_group10
 def test_workload_breadcrumb_menu(kiali_client, openshift_client, browser, pick_namespace):
     tests = WorkloadsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -24,7 +24,7 @@ def test_workload_breadcrumb_menu(kiali_client, openshift_client, browser, pick_
 
 
 @pytest.mark.p_ro_top
-@pytest.mark.p_group7
+@pytest.mark.p_ro_group10
 def test_workload_breadcrumb_namespace(kiali_client, openshift_client, browser, pick_namespace):
     tests = WorkloadsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -33,7 +33,7 @@ def test_workload_breadcrumb_namespace(kiali_client, openshift_client, browser, 
 
 
 @pytest.mark.p_ro_top
-@pytest.mark.p_group7
+@pytest.mark.p_ro_group2
 def test_workload_breadcrumb_object(kiali_client, openshift_client, browser, pick_namespace):
     tests = WorkloadsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -45,7 +45,7 @@ def test_workload_breadcrumb_object(kiali_client, openshift_client, browser, pic
 # putting to p_ro_top group although right now there are no tests changing health of app so
 # it could be in p_ro_top_safe
 @pytest.mark.p_ro_top
-@pytest.mark.p_group7
+@pytest.mark.p_ro_group2
 def test_application_breadcrumb_menu(kiali_client, openshift_client, browser, pick_namespace):
     tests = ApplicationsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -54,7 +54,7 @@ def test_application_breadcrumb_menu(kiali_client, openshift_client, browser, pi
 
 
 @pytest.mark.p_ro_top
-@pytest.mark.p_group7
+@pytest.mark.p_ro_group2
 def test_application_breadcrumb_namespace(kiali_client, openshift_client, browser, pick_namespace):
     tests = ApplicationsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -63,7 +63,7 @@ def test_application_breadcrumb_namespace(kiali_client, openshift_client, browse
 
 
 @pytest.mark.p_ro_top
-@pytest.mark.p_group7
+@pytest.mark.p_ro_group2
 def test_application_breadcrumb_object(kiali_client, openshift_client, browser, pick_namespace):
     tests = ApplicationsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -75,7 +75,7 @@ def test_application_breadcrumb_object(kiali_client, openshift_client, browser, 
 # putting to p_ro_top group although right now there are no tests changing health of app so
 # it could be in p_ro_top_safe
 @pytest.mark.p_ro_top
-@pytest.mark.p_group7
+@pytest.mark.p_ro_group2
 def test_service_breadcrumb_menu(kiali_client, openshift_client, browser, pick_namespace):
     tests = ServicesPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -84,7 +84,7 @@ def test_service_breadcrumb_menu(kiali_client, openshift_client, browser, pick_n
 
 
 @pytest.mark.p_ro_top
-@pytest.mark.p_group7
+@pytest.mark.p_ro_group2
 def test_service_breadcrumb_namespace(kiali_client, openshift_client, browser, pick_namespace):
     tests = ServicesPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -93,7 +93,7 @@ def test_service_breadcrumb_namespace(kiali_client, openshift_client, browser, p
 
 
 @pytest.mark.p_ro_top
-@pytest.mark.p_group7
+@pytest.mark.p_ro_group2
 def test_service_breadcrumb_object(kiali_client, openshift_client, browser, pick_namespace):
     tests = ServicesPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -105,7 +105,7 @@ def test_service_breadcrumb_object(kiali_client, openshift_client, browser, pick
 # putting to p_ro_top group although right now there are no tests changing health of app so
 # it could be in p_ro_top_safe
 @pytest.mark.p_ro_top
-@pytest.mark.p_group7
+@pytest.mark.p_ro_group2
 def test_config_breadcrumb_menu(kiali_client, openshift_client, browser):
     tests = IstioConfigPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -113,7 +113,7 @@ def test_config_breadcrumb_menu(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_ro_top
-@pytest.mark.p_group7
+@pytest.mark.p_ro_group2
 def test_config_breadcrumb_namespace(kiali_client, openshift_client, browser):
     tests = IstioConfigPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -121,7 +121,7 @@ def test_config_breadcrumb_namespace(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_ro_top
-@pytest.mark.p_group7
+@pytest.mark.p_ro_group2
 def test_config_breadcrumb_object(kiali_client, openshift_client, browser):
     tests = IstioConfigPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)

--- a/kiali_qe/tests/test_filters.py
+++ b/kiali_qe/tests/test_filters.py
@@ -28,7 +28,7 @@ CONFIG_KEPT_FILTER = []
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group10
+@pytest.mark.p_ro_group3
 def test_app_filters_kept(kiali_client, openshift_client, browser):
     app_filters = [
         {'name': ApplicationsPageFilter.ISTIO_SIDECAR.text, 'value': FILTER_PRESENT},
@@ -58,7 +58,7 @@ def test_app_filters_kept(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group10
+@pytest.mark.p_ro_group3
 def test_workloads_filters_kept(kiali_client, openshift_client, browser):
     wr_filters = [
         {'name': WorkloadsPageFilter.ISTIO_SIDECAR.text, 'value': FILTER_PRESENT},
@@ -91,7 +91,7 @@ def test_workloads_filters_kept(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group10
+@pytest.mark.p_ro_group3
 def test_services_filters_kept(kiali_client, openshift_client, browser):
     services_filters = [
         {'name': ServicesPageFilter.ISTIO_SIDECAR.text, 'value': FILTER_PRESENT},
@@ -121,7 +121,7 @@ def test_services_filters_kept(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group10
+@pytest.mark.p_ro_group8
 def test_config_filters_kept(kiali_client, openshift_client, browser):
     config_filters = [
         {'name': IstioConfigPageFilter.ISTIO_TYPE.text,

--- a/kiali_qe/tests/test_graph_page.py
+++ b/kiali_qe/tests/test_graph_page.py
@@ -13,7 +13,7 @@ from kiali_qe.utils.log import logger
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group9
+@pytest.mark.p_ro_group3
 def test_duration(browser):
     # get page instance
     page = GraphPage(browser)
@@ -27,7 +27,7 @@ def test_duration(browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group9
+@pytest.mark.p_ro_group3
 def test_refresh_interval(browser):
     # get page instance
     page = GraphPage(browser)
@@ -41,7 +41,7 @@ def test_refresh_interval(browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group9
+@pytest.mark.p_ro_group3
 def test_type(browser):
     # get page instance
     page = GraphPage(browser)
@@ -54,7 +54,7 @@ def test_type(browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group9
+@pytest.mark.p_ro_group3
 def test_filter(browser):
     # get page instance
     page = GraphPage(browser)

--- a/kiali_qe/tests/test_istio_config_page.py
+++ b/kiali_qe/tests/test_istio_config_page.py
@@ -7,7 +7,7 @@ ISTIO_SYSTEM = 'istio-system'
 
 
 @pytest.mark.p_ro_namespace
-@pytest.mark.p_group6
+@pytest.mark.p_ro_group4
 def test_pagination_feature(kiali_client, openshift_client, browser):
     tests = IstioConfigPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -18,7 +18,7 @@ def test_pagination_feature(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_ro_top_safe
-@pytest.mark.p_group10
+@pytest.mark.p_ro_group4
 def test_namespaces(kiali_client, openshift_client, browser):
     tests = IstioConfigPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -26,7 +26,7 @@ def test_namespaces(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group10
+@pytest.mark.p_ro_group4
 def test_filter_options(kiali_client, openshift_client, browser):
     tests = IstioConfigPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -34,16 +34,15 @@ def test_filter_options(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group10
+@pytest.mark.p_ro_group4
 def test_sort_options(kiali_client, openshift_client, browser):
     tests = IstioConfigPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
     tests.assert_sort_options()
 
 
-# p_group_last is used for tests which must be run at the end when all other test are done
 @pytest.mark.p_ro_top
-@pytest.mark.p_group_last
+@pytest.mark.p_ro_group4
 def test_filter_feature_random(kiali_client, openshift_client, browser):
     tests = IstioConfigPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -51,7 +50,7 @@ def test_filter_feature_random(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_ro_top
-@pytest.mark.p_group_last
+@pytest.mark.p_ro_group6
 def test_all_configs(kiali_client, openshift_client, browser):
     tests = IstioConfigPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -59,7 +58,7 @@ def test_all_configs(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_ro_top
-@pytest.mark.p_group_last
+@pytest.mark.p_ro_group4
 def test_all_configs_namespace(kiali_client, openshift_client, browser):
     tests = IstioConfigPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -68,7 +67,7 @@ def test_all_configs_namespace(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_ro_namespace
-@pytest.mark.p_group5
+@pytest.mark.p_ro_group4
 def test_config_details_random(kiali_client, openshift_client, browser, pick_namespace):
     tests = IstioConfigPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)

--- a/kiali_qe/tests/test_istio_objects_crud.py
+++ b/kiali_qe/tests/test_istio_objects_crud.py
@@ -42,7 +42,7 @@ SERVICE_ROLE_BINDING_BROKEN = 'service-role-binding-broken.yaml'
 
 
 @pytest.mark.p_crud_resource
-@pytest.mark.p_group1
+@pytest.mark.p_crud_group1
 def test_destination_rule(kiali_client, openshift_client, browser):
     destination_rule = get_yaml(istio_objects_path.strpath, DEST_RULE)
     destination_rule_dict = get_dict(istio_objects_path.strpath, DEST_RULE)
@@ -66,7 +66,7 @@ def test_destination_rule(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_crud_resource
-@pytest.mark.p_group1
+@pytest.mark.p_crud_group1
 def test_destination_rule_broken(kiali_client, openshift_client, browser):
     destination_rule_broken = get_yaml(istio_objects_path.strpath, DEST_RULE_BROKEN)
     destination_rule_broken_dict = get_dict(istio_objects_path.strpath, DEST_RULE_BROKEN)
@@ -92,7 +92,7 @@ def test_destination_rule_broken(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_crud_resource
-@pytest.mark.p_group2
+@pytest.mark.p_crud_group2
 def test_virtual_service(kiali_client, openshift_client, browser):
     virtual_service = get_yaml(istio_objects_path.strpath, VIRTUAL_SERVICE)
     virtual_service_dict = get_dict(istio_objects_path.strpath, VIRTUAL_SERVICE)
@@ -118,7 +118,7 @@ def test_virtual_service(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_crud_resource
-@pytest.mark.p_group2
+@pytest.mark.p_crud_group2
 def test_virtual_service_broken(kiali_client, openshift_client, browser):
     virtual_service_broken = get_yaml(istio_objects_path.strpath, VIRTUAL_SERVICE_BROKEN)
     virtual_service_broken_dict = get_dict(istio_objects_path.strpath, VIRTUAL_SERVICE_BROKEN)
@@ -148,7 +148,7 @@ def test_virtual_service_broken(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_crud_resource
-@pytest.mark.p_group2
+@pytest.mark.p_crud_group2
 def test_virtual_service_broken_weight(kiali_client, openshift_client, browser):
     virtual_service_broken = get_yaml(istio_objects_path.strpath,
                                       VIRTUAL_SERVICE_BROKEN_WEIGHT)
@@ -180,7 +180,7 @@ def test_virtual_service_broken_weight(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_crud_resource
-@pytest.mark.p_group3
+@pytest.mark.p_crud_group3
 def test_virtual_service_broken_weight_text(kiali_client, openshift_client, browser):
     virtual_service_broken = get_yaml(istio_objects_path.strpath,
                                       VIRTUAL_SERVICE_BROKEN_WEIGHT_TEXT)
@@ -213,7 +213,7 @@ def test_virtual_service_broken_weight_text(kiali_client, openshift_client, brow
 
 
 @pytest.mark.p_crud_resource
-@pytest.mark.p_group3
+@pytest.mark.p_crud_group3
 def test_quota_spec(kiali_client, openshift_client, browser):
     quota_spec = get_yaml(istio_objects_path.strpath, QUOTA_SPEC)
     quota_spec_dict = get_dict(istio_objects_path.strpath, QUOTA_SPEC)
@@ -235,7 +235,7 @@ def test_quota_spec(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_crud_resource
-@pytest.mark.p_group3
+@pytest.mark.p_crud_group3
 def test_quota_spec_binding(kiali_client, openshift_client, browser):
     quota_spec_binding = get_yaml(istio_objects_path.strpath, QUOTA_SPEC_BINDING)
     quota_spec_binding_dict = get_dict(istio_objects_path.strpath, QUOTA_SPEC_BINDING)
@@ -257,7 +257,7 @@ def test_quota_spec_binding(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_crud_resource
-@pytest.mark.p_group3
+@pytest.mark.p_crud_group3
 def test_gateway(kiali_client, openshift_client, browser, pick_namespace):
     gateway = get_yaml(istio_objects_path.strpath, GATEWAY)
     gateway_dict = get_dict(istio_objects_path.strpath, GATEWAY)
@@ -280,7 +280,7 @@ def test_gateway(kiali_client, openshift_client, browser, pick_namespace):
 
 
 @pytest.mark.p_crud_resource
-@pytest.mark.p_group1
+@pytest.mark.p_crud_group1
 def test_service_entry(kiali_client, openshift_client, browser):
     yaml = get_yaml(istio_objects_path.strpath, SERVICE_ENTRY)
     _dict = get_dict(istio_objects_path.strpath, SERVICE_ENTRY)
@@ -302,11 +302,10 @@ def test_service_entry(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_crud_resource
-@pytest.mark.p_group6
+@pytest.mark.p_crud_group4
 def test_service_mesh_rbac_config(kiali_client, openshift_client, browser):
     yaml = get_yaml(istio_objects_path.strpath, SERVICE_MESH_RBAC_CONFIG)
     _dict = get_dict(istio_objects_path.strpath, SERVICE_MESH_RBAC_CONFIG)
-
     _istio_config_test(kiali_client, openshift_client, browser,
                        _dict,
                        yaml,
@@ -324,7 +323,7 @@ def test_service_mesh_rbac_config(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_crud_resource
-@pytest.mark.p_group6
+@pytest.mark.p_crud_group4
 def test_rbac_config(kiali_client, openshift_client, browser):
     yaml = get_yaml(istio_objects_path.strpath, RBAC_CONFIG)
     _dict = get_dict(istio_objects_path.strpath, RBAC_CONFIG)
@@ -346,7 +345,7 @@ def test_rbac_config(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_crud_resource
-@pytest.mark.p_group8
+@pytest.mark.p_crud_group5
 def test_service_role(kiali_client, openshift_client, browser):
     yaml = get_yaml(istio_objects_path.strpath, SERVICE_ROLE)
     _dict = get_dict(istio_objects_path.strpath, SERVICE_ROLE)
@@ -368,7 +367,7 @@ def test_service_role(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_crud_resource
-@pytest.mark.p_group8
+@pytest.mark.p_crud_group5
 def test_service_role_broken(kiali_client, openshift_client, browser):
     yaml = get_yaml(istio_objects_path.strpath, SERVICE_ROLE_BROKEN)
     _dict = get_dict(istio_objects_path.strpath, SERVICE_ROLE_BROKEN)
@@ -392,7 +391,7 @@ def test_service_role_broken(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_crud_resource
-@pytest.mark.p_group8
+@pytest.mark.p_crud_group5
 def test_service_role_binding(kiali_client, openshift_client, browser):
     _role_yaml = get_yaml(istio_objects_path.strpath, SERVICE_ROLE)
     _role_dict = get_dict(istio_objects_path.strpath, SERVICE_ROLE)
@@ -426,7 +425,7 @@ def test_service_role_binding(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_crud_resource
-@pytest.mark.p_group8
+@pytest.mark.p_crud_group5
 def test_service_role_binding_broken(kiali_client, openshift_client, browser):
     _role_yaml = get_yaml(istio_objects_path.strpath, SERVICE_ROLE)
     _role_dict = get_dict(istio_objects_path.strpath, SERVICE_ROLE)

--- a/kiali_qe/tests/test_login.py
+++ b/kiali_qe/tests/test_login.py
@@ -6,7 +6,7 @@ from kiali_qe.utils.conf import env as cfg
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group8
+@pytest.mark.p_ro_group5
 @pytest.mark.skipif(cfg.kiali.auth_type == "oauth", reason="does not run on oauth")
 def test_login(browser):
     # load root page
@@ -22,7 +22,7 @@ def test_login(browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group8
+@pytest.mark.p_ro_group5
 @pytest.mark.skipif(cfg.kiali.auth_type == "oauth", reason="does not run on oauth")
 def test_invalid_login(browser):
     # load root page

--- a/kiali_qe/tests/test_menu.py
+++ b/kiali_qe/tests/test_menu.py
@@ -7,7 +7,7 @@ from kiali_qe.utils.log import logger
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group9
+@pytest.mark.p_ro_group5
 def test_menu(browser, kiali_client):
     # load root page
     page = RootPage(browser)
@@ -31,7 +31,7 @@ def test_menu(browser, kiali_client):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group9
+@pytest.mark.p_ro_group5
 def test_toggle(browser):
     # load root page
     page = RootPage(browser)
@@ -42,7 +42,7 @@ def test_toggle(browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group9
+@pytest.mark.p_ro_group5
 def test_help_menu(browser):
     # load root page
     page = RootPage(browser)
@@ -54,7 +54,7 @@ def test_help_menu(browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group9
+@pytest.mark.p_ro_group5
 def test_user_menu(browser):
     # load root page
     page = RootPage(browser)

--- a/kiali_qe/tests/test_navbar.py
+++ b/kiali_qe/tests/test_navbar.py
@@ -7,7 +7,7 @@ from kiali_qe.utils.log import logger
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group10
+@pytest.mark.p_ro_group6
 def test_about(browser, kiali_client):
     # load root page
     page = RootPage(browser)
@@ -69,7 +69,7 @@ def _get_version(versions, key):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group10
+@pytest.mark.p_ro_group6
 def test_help_menu(browser):
     # load root page
     page = RootPage(browser)

--- a/kiali_qe/tests/test_overview_page.py
+++ b/kiali_qe/tests/test_overview_page.py
@@ -5,7 +5,7 @@ from kiali_qe.components.enums import OverviewPageType
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group6
+@pytest.mark.p_ro_group6
 def test_filter_options(kiali_client, openshift_client, browser):
     tests = OverviewPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -13,7 +13,7 @@ def test_filter_options(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group6
+@pytest.mark.p_ro_group6
 def test_sort_options(kiali_client, openshift_client, browser):
     tests = OverviewPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -21,7 +21,7 @@ def test_sort_options(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group6
+@pytest.mark.p_ro_group6
 def test_type_options(kiali_client, openshift_client, browser):
     tests = OverviewPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -31,7 +31,7 @@ def test_type_options(kiali_client, openshift_client, browser):
 # putting to p_ro_top group although right now there are no tests changing health of app so
 # it could be in p_ro_top_safe
 @pytest.mark.p_ro_top
-@pytest.mark.p_group6
+@pytest.mark.p_ro_group6
 def test_all_app_overviews(kiali_client, openshift_client, browser):
     tests = OverviewPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -39,7 +39,7 @@ def test_all_app_overviews(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_ro_top
-@pytest.mark.p_group6
+@pytest.mark.p_ro_group6
 def test_all_services_overviews(kiali_client, openshift_client, browser):
     tests = OverviewPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -47,7 +47,7 @@ def test_all_services_overviews(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_ro_top
-@pytest.mark.p_group6
+@pytest.mark.p_ro_group6
 def test_all_workloads_overviews(kiali_client, openshift_client, browser):
     tests = OverviewPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)

--- a/kiali_qe/tests/test_routing_wizard.py
+++ b/kiali_qe/tests/test_routing_wizard.py
@@ -11,7 +11,7 @@ BOOKINFO_2 = 'bookinfo2'
 
 
 @pytest.mark.p_ro_namespace
-@pytest.mark.p_group5
+@pytest.mark.p_crud_group6
 def test_weighted_routing_single(kiali_client, openshift_client, browser, pick_namespace):
     tests = ServicesPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -32,7 +32,7 @@ def test_weighted_routing_single(kiali_client, openshift_client, browser, pick_n
 
 
 @pytest.mark.p_ro_namespace
-@pytest.mark.p_group5
+@pytest.mark.p_crud_group6
 def test_matching_routing_multi(kiali_client, openshift_client, browser, pick_namespace):
     tests = ServicesPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -53,7 +53,7 @@ def test_matching_routing_multi(kiali_client, openshift_client, browser, pick_na
 
 
 @pytest.mark.p_ro_namespace
-@pytest.mark.p_group5
+@pytest.mark.p_crud_group6
 def test_suspend_traffic_multi(kiali_client, openshift_client, browser, pick_namespace):
     tests = ServicesPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)

--- a/kiali_qe/tests/test_services_page.py
+++ b/kiali_qe/tests/test_services_page.py
@@ -8,7 +8,7 @@ ISTIO_SYSTEM = 'istio-system'
 
 
 @pytest.mark.p_ro_namespace
-@pytest.mark.p_group9
+@pytest.mark.p_ro_group7
 def test_pagination_feature(kiali_client, openshift_client, browser):
     tests = ServicesPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -18,7 +18,7 @@ def test_pagination_feature(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_ro_top_safe
-@pytest.mark.p_group4
+@pytest.mark.p_ro_group7
 def test_namespaces(kiali_client, openshift_client, browser):
     tests = ServicesPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -26,7 +26,7 @@ def test_namespaces(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group4
+@pytest.mark.p_ro_group7
 def test_filter_options(kiali_client, openshift_client, browser):
     tests = ServicesPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -34,7 +34,7 @@ def test_filter_options(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group4
+@pytest.mark.p_ro_group7
 def test_sort_options(kiali_client, openshift_client, browser):
     tests = ServicesPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -44,7 +44,7 @@ def test_sort_options(kiali_client, openshift_client, browser):
 # putting to p_ro_top group although right now there are no tests changing health of app so
 # it could be in p_ro_top_safe
 @pytest.mark.p_ro_top
-@pytest.mark.p_group4
+@pytest.mark.p_ro_group7
 def test_filter_feature_random(kiali_client, openshift_client, browser):
     tests = ServicesPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -54,7 +54,7 @@ def test_filter_feature_random(kiali_client, openshift_client, browser):
 # putting to p_ro_top group although right now there are no tests changing health of app so
 # it could be in p_ro_top_safe
 @pytest.mark.p_ro_top
-@pytest.mark.p_group4
+@pytest.mark.p_ro_group7
 def test_all_services(kiali_client, openshift_client, browser):
     tests = ServicesPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -62,7 +62,7 @@ def test_all_services(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_ro_top
-@pytest.mark.p_group4
+@pytest.mark.p_ro_group7
 def test_all_services_namespace(kiali_client, openshift_client, browser):
     tests = ServicesPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -70,7 +70,7 @@ def test_all_services_namespace(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_ro_namespace
-@pytest.mark.p_group5
+@pytest.mark.p_ro_group9
 def test_service_details_random(kiali_client, openshift_client, browser, pick_namespace):
     tests = ServicesPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)

--- a/kiali_qe/tests/test_workloads_page.py
+++ b/kiali_qe/tests/test_workloads_page.py
@@ -8,7 +8,7 @@ ISTIO_SYSTEM = 'istio-system'
 
 
 @pytest.mark.p_ro_namespace
-@pytest.mark.p_group9
+@pytest.mark.p_ro_group8
 def test_pagination_feature(kiali_client, openshift_client, browser):
     tests = WorkloadsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -18,7 +18,7 @@ def test_pagination_feature(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_ro_top_safe
-@pytest.mark.p_group7
+@pytest.mark.p_ro_group8
 def test_namespaces(kiali_client, openshift_client, browser):
     tests = WorkloadsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -26,7 +26,7 @@ def test_namespaces(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group7
+@pytest.mark.p_ro_group8
 def test_filter_options(kiali_client, openshift_client, browser):
     tests = WorkloadsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -34,7 +34,7 @@ def test_filter_options(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_atomic
-@pytest.mark.p_group7
+@pytest.mark.p_ro_group8
 def test_sort_options(kiali_client, openshift_client, browser):
     tests = WorkloadsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -44,7 +44,7 @@ def test_sort_options(kiali_client, openshift_client, browser):
 # putting to p_ro_top group although right now there are no tests changing health of app so
 # it could be in p_ro_top_safe
 @pytest.mark.p_ro_top
-@pytest.mark.p_group7
+@pytest.mark.p_ro_group8
 def test_all_workloads(kiali_client, openshift_client, browser):
     tests = WorkloadsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -52,7 +52,7 @@ def test_all_workloads(kiali_client, openshift_client, browser):
 
 
 @pytest.mark.p_ro_top
-@pytest.mark.p_group7
+@pytest.mark.p_ro_group9
 def test_all_workloads_namespace(kiali_client, openshift_client, browser):
     tests = WorkloadsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
@@ -62,7 +62,7 @@ def test_all_workloads_namespace(kiali_client, openshift_client, browser):
 # putting to p_ro_top group although right now there are no tests changing health of app so
 # it could be in p_ro_top_safe
 @pytest.mark.p_ro_top
-@pytest.mark.p_group7
+@pytest.mark.p_ro_group10
 def test_workload_details_random(kiali_client, openshift_client, browser, pick_namespace):
     tests = WorkloadsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,6 +11,26 @@ markers =
     p_group8
     p_group9
     p_group10
+    p_ro_group1
+    p_ro_group2
+    p_ro_group3
+    p_ro_group4
+    p_ro_group5
+    p_ro_group6
+    p_ro_group7
+    p_ro_group8
+    p_ro_group9
+    p_ro_group10
+    p_crud_group1
+    p_crud_group2
+    p_crud_group3
+    p_crud_group4
+    p_crud_group5
+    p_crud_group6
+    p_crud_group7
+    p_crud_group8
+    p_crud_group9
+    p_crud_group10
     p_group_last
     hookwrapper
     p_ro_namespace


### PR DESCRIPTION
Run 10 groups of UI tests first which are RO and then 6 groups of tests which would collide with first group of tests and then run the last group
