### PR TITLE
Use 1m for rateInterval when getting health from REST

### DIFF
--- a/kiali_qe/components/enums.py
+++ b/kiali_qe/components/enums.py
@@ -51,7 +51,7 @@ class PaginationPerPage(Enum):
     FIFTEEN = 15
 
 
-class GraphPageDuration(StringEnum):
+class TimeIntervalUIText(StringEnum):
     LAST_MINUTE = ('Last 1m')
     LAST_5_MINUTES = ('Last 5m')
     LAST_10_MINUTES = ('Last 10m')
@@ -59,6 +59,16 @@ class GraphPageDuration(StringEnum):
     LAST_HOUR = ('Last 1h')
     LAST_3_HOURS = ('Last 3h')
     LAST_6_HOURS = ('Last 6h')
+
+
+class TimeIntervalRestParam(StringEnum):
+    LAST_MINUTE = ('1m')
+    LAST_5_MINUTES = ('5m')
+    LAST_10_MINUTES = ('10m')
+    LAST_30_MINUTES = ('30m')
+    LAST_HOUR = ('1h')
+    LAST_3_HOURS = ('3h')
+    LAST_6_HOURS = ('6h')
 
 
 class GraphRefreshInterval(StringEnum):

--- a/kiali_qe/tests/__init__.py
+++ b/kiali_qe/tests/__init__.py
@@ -14,7 +14,7 @@ from kiali_qe.components.enums import (
     MetricsHistograms,
     InboundMetricsFilter,
     OutboundMetricsFilter,
-    GraphPageDuration,
+    TimeIntervalUIText,
     GraphRefreshInterval,
     OverviewPageType,
     RoutingWizardType,
@@ -327,7 +327,7 @@ class AbstractListPageTest(object):
         self._assert_metrics_options(metrics_page, MetricsSource, 'destination')
 
     def _assert_metrics_duration(self, metrics_page):
-        self._assert_metrics_options(metrics_page, GraphPageDuration, 'duration')
+        self._assert_metrics_options(metrics_page, TimeIntervalUIText, 'duration')
 
     def _assert_metrics_interval(self, metrics_page):
         self._assert_metrics_options(metrics_page, GraphRefreshInterval, 'interval')

--- a/kiali_qe/tests/test_graph_page.py
+++ b/kiali_qe/tests/test_graph_page.py
@@ -4,7 +4,7 @@ from kiali_qe.components.enums import (
     GraphPageDisplayFilter,
     GraphType,
     EdgeLabelsFilter,
-    GraphPageDuration,
+    TimeIntervalUIText,
     GraphRefreshInterval
 )
 from kiali_qe.pages import GraphPage
@@ -18,7 +18,7 @@ def test_duration(browser):
     # get page instance
     page = GraphPage(browser)
     # test options
-    options_defined = [item.text for item in GraphPageDuration]
+    options_defined = [item.text for item in TimeIntervalUIText]
     duration = page.duration
     options_listed = duration.options
     logger.debug('Options[defined:{}, listed:{}]'.format(options_defined, options_listed))


### PR DESCRIPTION
UI by default shows Last 1 minute when showing health and rest was using
10m by default which was causing mishmash and test failures.
Now we use 1m for rateInterval when getting health from REST so it
should match UI.