### PR TITLE
UI:Fixed_service_grafana

### DIFF
--- a/kiali_qe/tests/__init__.py
+++ b/kiali_qe/tests/__init__.py
@@ -1618,7 +1618,7 @@ class ServicesPageTest(AbstractListPageTest):
                                   namespace)
 
         if check_metrics:
-            self.assert_metrics_options(service_details_ui.inbound_metrics, check_grafana=True)
+            self.assert_metrics_options(service_details_ui.inbound_metrics, check_grafana=False)
 
         self.assert_traces_tab(service_details_ui.traces_tab)
 


### PR DESCRIPTION
Random  Service TC's are failing, Because the Grafana link has removed in the latest UI changes.

This change will fix the TC's failures in the upstream run



kiali_qe.tests.test_services_page.test_service_details_random 


>       assert metrics_page.view_in_grafana

   AssertionError