### PR TITLE
fix_duplicate_sidecar_error

### DIFF
--- a/kiali_qe/tests/test_istio_config_validation.py
+++ b/kiali_qe/tests/test_istio_config_validation.py
@@ -464,12 +464,16 @@ def test_duplicate_sidecar_errors(kiali_client, openshift_client):
                 object_type='Sidecar',
                 object_name='dupliacate-sidecar1-auto',
                 namespace=BOOKINFO,
-                error_messages=[KIA0002]),
+                error_messages=[KIA0002,
+                                KIA1004,
+                                KIA1004]),
             ConfigValidationObject(
                 object_type='Sidecar',
                 object_name='dupliacate-sidecar2-auto',
                 namespace=BOOKINFO,
-                error_messages=[KIA0002])
+                error_messages=[KIA0002,
+                                KIA1004,
+                                KIA1004])
         ])
 
 


### PR DESCRIPTION
https://github.com/kiali/kiali/pull/4387

updated according to this PR.


Applied yaml manually and verified the test case.


```
apiVersion: networking.istio.io/v1alpha3
kind: Sidecar
metadata:
  name: dupliacate-sidecar1-auto
  namespace: bookinfo
spec:
  egress:
    # If this config is applied, sidecars will only be able to talk to
    # other services in the same namespace, in addition to istio-telemetry
    # and istio-policy
  - hosts:
    - "./*"
    - "istio-system/istio-telemetry.istio-system.svc.cluster.local"
    - "istio-system/istio-policy.istio-system.svc.cluster.local"
```

![sidecar_1](https://user-images.githubusercontent.com/55099523/141382369-a629492a-d35b-44d0-93bd-3153f47eb9e3.gif)


![duplicate_sidecar_errors](https://user-images.githubusercontent.com/55099523/141382422-9728e6d0-45b5-4860-8521-26b586ffae30.png)
