### PR TITLE
load balancer, routing wizard

### DIFF
--- a/kiali_qe/components/__init__.py
+++ b/kiali_qe/components/__init__.py
@@ -779,6 +779,7 @@ class Actions(Widget):
         self._abort_switch = ButtonSwitch(parent=self, label="Add HTTP Abort")
         self._connection_pool_switch = ButtonSwitch(parent=self, label="Add Connection Pool")
         self._outlier_detection_switch = ButtonSwitch(parent=self, label="Add Outlier Detection")
+        self._http_header_name = TextInput(parent=self, locator='//input[@name="httpHeaderName"]')
 
     def __locator__(self):
         return self.locator
@@ -1228,10 +1229,11 @@ class Actions(Widget):
         if load_balancer and load_balancer_type:
             self.browser.click(_traffic_tab)
             self._loadbalancer_switch.on()
-            if load_balancer_type:
-                wait_displayed(self._loadbalancer_type)
-                self._loadbalancer_type.select(load_balancer_type.text)
+            if load_balancer_type and self._loadbalancer_type.is_displayed:
+                    wait_displayed(self._loadbalancer_type)
+                    self._loadbalancer_type.select(load_balancer_type.text)
         else:
+            self._http_header_name.fill('test')
             self.browser.click(_traffic_tab)
             self._loadbalancer_switch.off()
         if gateway:

--- a/kiali_qe/tests/__init__.py
+++ b/kiali_qe/tests/__init__.py
@@ -1856,11 +1856,6 @@ class ServicesPageTest(AbstractListPageTest):
         assert service_details_rest.virtual_services[0].name == name
         assert service_details_rest.destination_rules[0].name == name
 
-        if load_balancer_type:
-            assert word_in_text(load_balancer_type.text.lower(),
-                                service_details_rest.destination_rules[0].traffic_policy,
-                                load_balancer)
-
         if tls:
             assert word_in_text(tls.text.lower(),
                                 service_details_rest.destination_rules[0].traffic_policy,

--- a/kiali_qe/tests/__init__.py
+++ b/kiali_qe/tests/__init__.py
@@ -1982,11 +1982,6 @@ class ServicesPageTest(AbstractListPageTest):
         assert service_details_rest.virtual_services[0].name == name
         assert service_details_rest.destination_rules[0].name == name
 
-        if load_balancer_type:
-            assert word_in_text(load_balancer_type.text.lower(),
-                                service_details_rest.destination_rules[0].traffic_policy,
-                                load_balancer)
-
         if tls and tls.text != RoutingWizardTLS.UNSET.text:
             assert word_in_text(tls.text.lower(),
                                 service_details_rest.destination_rules[0].traffic_policy,


### PR DESCRIPTION
- deleting load balancer type request (obsolete API)
- fixing test_routing_wizard.py (test_weighted_routing_single, test_tcp_routing_single)
