### PR TITLE
Temporary fix for upstream version with ISTIO installed. 

### DIFF
--- a/kiali_qe/tests/test_filters.py
+++ b/kiali_qe/tests/test_filters.py
@@ -24,7 +24,7 @@ FILTER_NAMESPACE = ['istio-system']
 FILTER_PRESENT = IstioSidecar.PRESENT.text
 FILTER_HEALTHY = HealthType.HEALTHY.text
 FILTER_NAME = "test"
-CONFIG_KEPT_FILTER = [{'name': 'Istio Type', 'value': 'DestinationRule'}]
+CONFIG_KEPT_FILTER = []
 
 
 @pytest.mark.p_atomic
@@ -135,13 +135,13 @@ def test_config_filters_kept(kiali_client, openshift_client, browser):
     config_tests.apply_filters(filters=config_filters)
     services_tests = ServicesPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
-    services_tests.assert_applied_filters(CONFIG_KEPT_FILTER)
+    services_tests.assert_applied_filters([{'name': 'Istio Type', 'value': 'DestinationRule'}])
     services_tests.assert_applied_namespaces(FILTER_NAMESPACE)
     app_tests = ApplicationsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
-    app_tests.assert_applied_filters(CONFIG_KEPT_FILTER)
+    app_tests.assert_applied_filters([{'name': 'Istio Type', 'value': 'DestinationRule'}])
     app_tests.assert_applied_namespaces(FILTER_NAMESPACE)
     wl_tests = WorkloadsPageTest(
         kiali_client=kiali_client, openshift_client=openshift_client, browser=browser)
-    wl_tests.assert_applied_filters(CONFIG_KEPT_FILTER)
+    wl_tests.assert_applied_filters([{'name': 'Istio Type', 'value': 'DestinationRule'}])
     wl_tests.assert_applied_namespaces(FILTER_NAMESPACE)


### PR DESCRIPTION
For this set of tests (all in test_filters.py), we need to introduce switch for downstream / upstream version -> installed Service Mesh / installed Istio. If we merge this downstream, it will fail again