### PR TITLE
disabling 2 testcases for migration

### DIFF
--- a/kiali_qe/tests/__init__.py
+++ b/kiali_qe/tests/__init__.py
@@ -2361,7 +2361,7 @@ class IstioConfigPageTest(AbstractListPageTest):
                         assert '\"portLevelMtls\": \"{}\": \"mode\": \"{}\"'.format(_key, _value) \
                             in config_details_rest.text.replace('{', '').replace('}', '')
 
-    def test_requestauth_create(self, name, namespaces, expected_created=True,
+    def __test_requestauth_create(self, name, namespaces, expected_created=True,
                                 labels=None, jwt_rules={}):
         logger.debug('Creating RequestAuthentication: {}, from namespaces: {}'.format(
             name,

--- a/kiali_qe/tests/test_graph_page.py
+++ b/kiali_qe/tests/test_graph_page.py
@@ -121,7 +121,7 @@ def test_find_hide(browser):
 
 @pytest.mark.p_atomic
 @pytest.mark.p_ro_group3
-def test_layout(browser):
+def __test_layout(browser):
     # get page instance
     page = GraphPage(browser)
     page.namespace.check(ISTIO_SYSTEM)


### PR DESCRIPTION
__test_requestauth_create
__test_layout